### PR TITLE
Add simple Flask web app for modify_pf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # dealwithpf
+
+该仓库包含 `modify_pf.py` 脚本以及一个基于 Flask 的简易 Web 应用，用于在浏览器中对 `.pf` 文件进行处理。
+
+## 运行 Web 应用
+
+1. 安装依赖：
+   ```bash
+   pip install Flask
+   ```
+2. 启动服务：
+   ```bash
+   python app.py
+   ```
+3. 在浏览器中访问 `http://127.0.0.1:5000/`，上传 `.pf` 文件即可获得处理后的结果。
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,29 @@
+from flask import Flask, request, render_template, send_file
+import os
+import tempfile
+from modify_pf import modify_pf_file
+
+app = Flask(__name__)
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        pf_file = request.files.get('pf_file')
+        if not pf_file:
+            return render_template('index.html', message='请上传 .pf 文件')
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = os.path.join(tmpdir, pf_file.filename)
+            pf_file.save(input_path)
+            mods = {
+                '绘图比例': {1: '1000', 2: '200'},
+                '断链': {3: '""', 11: '""'},
+                '模型管理': {5: '改移道路'},
+                '数模': {0: '2000地形图总和-8号色'},
+                '五线谱': {0: '复杂的改移公道路纵断面'},
+            }
+            modify_pf_file(input_path, mods, enable_model_filename=True)
+            return send_file(input_path, as_attachment=True)
+    return render_template('index.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="zh-cn">
+<head>
+    <meta charset="UTF-8">
+    <title>modify_pf Web 应用</title>
+</head>
+<body>
+    <h1>上传 .pf 文件</h1>
+    {% if message %}<p style="color:red;">{{ message }}</p>{% endif %}
+    <form method="post" enctype="multipart/form-data">
+        <input type="file" name="pf_file" accept=".pf">
+        <button type="submit">提交并下载处理结果</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal Flask app and HTML template to process `.pf` files in a browser
- document how to run the web interface

## Testing
- `python -m py_compile modify_pf.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_685264b4b204832ab5c0feac3e189da5